### PR TITLE
Use aliases for `git bare-branch` and `git ptrack`

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -18,6 +18,9 @@
   wdiff = diff --color-words
   sexytime = !git push -u && git pull-request
   tree-graph = log --graph --simplify-by-decoration --pretty=format:'%d' --all
+  bare-branch = !git symbolic-ref HEAD | sed 's|refs/heads/||g'
+  ptrack = !git push -u origin $(git bare-branch)
+
 [color]
   branch = auto
   diff = auto

--- a/bin/git-bare-branch
+++ b/bin/git-bare-branch
@@ -1,2 +1,0 @@
-#!/bin/bash
-git branch | grep ^\* | awk '{print $2}'

--- a/bin/git-ptrack
+++ b/bin/git-ptrack
@@ -1,3 +1,0 @@
-#!/bin/bash
-current_branch=`git bare-branch`
-git push -u origin $current_branch


### PR DESCRIPTION
ZSH will complete an alias for you.

I also changed the `bare-branch` command to use `git symbolic-ref`. It's porcelain so its a bit faster than `git branch`.
